### PR TITLE
Add html options for select box markup

### DIFF
--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'administrate-field-enum'
-  s.version = '0.0.7'
+  s.version = '0.0.8'
   s.authors = ['Balbina Santana', 'Adrian Rangel']
   s.email = ['adrian@disruptiveangels.com']
   s.homepage = 'https://github.com/DisruptiveAngels/administrate-field-enum'

--- a/app/views/fields/enum/_form.html.erb
+++ b/app/views/fields/enum/_form.html.erb
@@ -26,5 +26,6 @@ By default, the input is a select field for the enum attributes.
     end,
     f.object.public_send(field.attribute.to_s)
   ),
-  include_blank: false) %>
+  { include_blank: false },
+  field.html_options) %>
 </div>

--- a/lib/administrate/field/enum.rb
+++ b/lib/administrate/field/enum.rb
@@ -8,6 +8,10 @@ module Administrate
         data.humanize unless data.nil?
       end
 
+      def html_options
+        options[:html] || {}
+      end
+
       class Engine < ::Rails::Engine
       end
     end

--- a/spec/lib/administrate/field/enum_spec.rb
+++ b/spec/lib/administrate/field/enum_spec.rb
@@ -11,4 +11,25 @@ describe Administrate::Field::Enum do
       expect(path).to eq("/fields/enum/#{page}")
     end
   end
+
+  describe '#html_options' do
+    it 'returns a hash of :html options' do
+      page = :show
+      field = Administrate::Field::Enum.with_options(html: { disabled: true, hidden: true, class: 'test' })
+                                       .new(:status, 'status', page)
+
+      expect(field.html_options[:disabled]).to be_truthy
+      expect(field.html_options[:hidden]).to be_truthy
+      expect(field.html_options[:class]).to eq('test')
+    end
+
+    it 'is empty by default' do
+      page = :show
+      field = Administrate::Field::Enum.new(:status, 'status', page)
+
+      expect(field.html_options[:disabled]).to be_falsy
+      expect(field.html_options[:hidden]).to be_falsy
+      expect(field.html_options[:class]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Why?
It would be great to conditionally make the select box this field renders on the edit form disabled, hidden, or to otherwise supply html attributes to it.

## Changes
- Added a fourth `html_options` hash to the `select` helper call, supplied to the `with_options` method exposed by Administrate's `Field` base class.