### PR TITLE
.gemspec: Depends solely on administrate

### DIFF
--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -14,6 +14,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency 'administrate'
-  s.add_dependency 'rails', '>= 4.2', '<= 6.0'
+  s.add_dependency 'administrate', '~> 0.12'
 end


### PR DESCRIPTION
The gem works on rails 6. Atleast on my projects.

The gem should support any rails version supported by supported administrate version.
Administrate already specify its supported version