### PR TITLE
Allow blank for enum that is not required.

### DIFF
--- a/app/views/fields/enum/_form.html.erb
+++ b/app/views/fields/enum/_form.html.erb
@@ -26,6 +26,6 @@ By default, the input is a select field for the enum attributes.
     end,
     f.object.public_send(field.attribute.to_s)
   ),
-  { include_blank: false },
+  { include_blank: !f.object.class.validators_on(field.attribute.to_s).map(&:class).include?(ActiveRecord::Validations::PresenceValidator) },
   field.html_options) %>
 </div>


### PR DESCRIPTION
The same change as referenced in #7 - but with the updates as requested.