### PR TITLE
Add option to filter select values

### DIFF
--- a/.customink/catalog.yaml
+++ b/.customink/catalog.yaml
@@ -1,0 +1,28 @@
+name: administrate-field-enum
+
+owner: tailor-made # team definitions at https://app.opslevel.com/teams
+
+purpose: # multiple choice
+  # - do_not_track # demo testing personal - will not be tracked in catalog
+  # - app
+  - library
+  # - configuration
+  # - other # example: frontend_dataset
+deployment_type: # multiple choice
+  # - kubernetes
+  # - infrastructure_serverless
+  - package
+  # - cli
+  # - data
+  # - docker-image
+
+# tier: tier_1 # Mission-critical service or repository. Failure could result in significant impact to revenue or reputation.
+# tier: tier_2 # Customer-facing service or repository. Failure results in degraded experience for customers, although without significant impact to revenue or reputation.
+# tier: tier_3 # Internal service or repository. Failure could result in productivity being compromised within the company.
+# tier: tier_4 # Other service or repository. Failure doesn't result in immediate or significant impact.
+tier: tier_na # this repo does not have a tier. typically libraries
+
+properties:
+  public_facing: false
+  pci: false
+  pii: false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @customink/tailor-made

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Bump/Close inactive PRs
+on:
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 90
+
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is open and inactive for 30 days. Merging PRs open after a long time is error-prone. Please proceed to merging or make a comment to keep it open. You can also prevent PRs from being tagged stale or closed with 'keep-open' tag. If there is no activity in 90 days, this PR will be closed"
+          close-pr-message: "This PR was closed because it has been inactive for 90 days since being marked as stale."
+
+          exempt-pr-labels: "keep-open,dependabot,dependencies"
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Administrate Field Enum Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.9] - 2021/12/29
+### Changed
+- allow gem installation on Rails 4.2 and higher

--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -3,8 +3,8 @@ $:.push File.expand_path('../lib', __FILE__)
 Gem::Specification.new do |s|
   s.name = 'administrate-field-enum'
   s.version = '0.0.9'
-  s.authors = ['Balbina Santana', 'Adrian Rangel']
-  s.email = ['adrian@disruptiveangels.com']
+  s.authors = ['Daniel Wheeler', 'Tailor Made']
+  s.email = ['tailor.made@customink.com']
   s.homepage = 'https://github.com/DisruptiveAngels/administrate-field-enum'
   s.summary = 'Enum field plugin for Administrate'
   s.description = s.summary

--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'administrate-field-enum'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.authors = ['Balbina Santana', 'Adrian Rangel']
   s.email = ['adrian@disruptiveangels.com']
   s.homepage = 'https://github.com/DisruptiveAngels/administrate-field-enum'
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.add_dependency 'administrate'
-  s.add_dependency 'rails', '>= 4.2', '<= 6.0'
+  s.add_dependency 'rails', '>= 4.2'
 end

--- a/app/views/fields/enum/_form.html.erb
+++ b/app/views/fields/enum/_form.html.erb
@@ -21,9 +21,7 @@ By default, the input is a select field for the enum attributes.
   <%= f.select(
   field.attribute,
   options_for_select(
-    f.object.class.public_send(field.attribute.to_s.pluralize).map do |k, v|
-      [I18n.t("activerecord.attributes.#{f.object.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
-    end,
+    field.filtered_options(f.object.class.public_send(field.attribute.to_s.pluralize)),
     f.object.public_send(field.attribute.to_s)
   ),
   { include_blank: false },

--- a/lib/administrate/field/enum.rb
+++ b/lib/administrate/field/enum.rb
@@ -12,6 +12,16 @@ module Administrate
         options[:html] || {}
       end
 
+      def option_filter
+        options[:option_filter] || Proc.new { true }
+      end
+
+      def filtered_options(options)
+        options.select(&option_filter).map do |k, v|
+          [I18n.t("activerecord.attributes.#{resource.class.name.underscore}.#{attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
+        end
+      end
+
       class Engine < ::Rails::Engine
       end
     end

--- a/spec/lib/administrate/field/enum_spec.rb
+++ b/spec/lib/administrate/field/enum_spec.rb
@@ -32,4 +32,34 @@ describe Administrate::Field::Enum do
       expect(field.html_options[:class]).to be_nil
     end
   end
+
+  describe '#option_filter' do
+    it 'returns a supplied option_filter Proc' do
+      page = :form
+      option_filter = Proc.new { |option| option != 'x' }
+      field = Administrate::Field::Enum.with_options(option_filter: option_filter)
+                                       .new(:status, 'status', page)
+
+      expect(field.option_filter).to eq(option_filter)
+    end
+
+    it 'returns a no-op filter Proc by default' do
+      page = :form
+      field = Administrate::Field::Enum.new(:status, 'status', page)
+
+      expect(field.evaluator.call).to be_truthy
+    end
+  end
+
+  describe '#filtered_options' do
+    it 'returns array of filtered arrays' do
+      page = :form
+      options = ['I', 'Am', 'Groot']
+      option_filter = Proc.new { |option| option != 'Am' }
+      field = Administrate::Field::Enum.with_options(option_filter: option_filter)
+                                       .new(:status, 'status', page)
+
+      expect(field.filtered_options(options)).to eq([['I', 'I'], ['Groot', 'Groot']])
+    end
+  end
 end


### PR DESCRIPTION
#### Why?
We had the need to restrict certain enum values from the dropdown select form

#### Changes
- Added `option_filter` which returns either a no-op filter proc by default or a filter proc that evaluates and filters the provided options and & `filtered_options` to return the new select options array 
- Updated `form.erb` to use `filtered_options`