### PR TITLE
Do not render i18n value of enum if data is nil

### DIFF
--- a/app/views/fields/enum/_index.html.erb
+++ b/app/views/fields/enum/_index.html.erb
@@ -14,4 +14,6 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<% if field.data %>
+  <%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<% end %>

--- a/app/views/fields/enum/_show.html.erb
+++ b/app/views/fields/enum/_show.html.erb
@@ -14,4 +14,6 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<% if field.data %>
+  <%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<% end %>


### PR DESCRIPTION
Currently the lib tries to render the i18n value of the field even when it is nil. The problem with this is that when you have some i18n of it like the following:
        matrimonial_regimes:
          community_property: Comunhão universal de bens
          partial_property: Comunhão parcial de bens
          separate_property: Separação de bens
the lib renders all values on the page as a hash:
{:community_property=>"Comunhão universal de bens", :partial_property=>"Comunhão parcial de bens",
:separate_property=>"Separação de bens"}

<img width="992" alt="image" src="https://github.com/valiot/administrate-field-enum/assets/771411/b85df5b5-d054-465b-9e25-467136b2b8b3">


This happens because the i18n key used on the view "activerecord.attributes.#{field.resource.class.name.underscore}.

will render everything on the top level of my enum translations.

This commit changes the views to not try to render if data is nil.