### PR TITLE
Bump to 0.0.9 and support administrate >= 0.12

### DIFF
--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'administrate-field-enum'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.authors = ['Balbina Santana', 'Adrian Rangel']
   s.email = ['adrian@disruptiveangels.com']
   s.homepage = 'https://github.com/DisruptiveAngels/administrate-field-enum'
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency 'administrate', '~> 0.12'
+  s.add_dependency 'administrate', '>= 0.12'
 end


### PR DESCRIPTION
## Summary
- Relax administrate dependency from `~> 0.12` to `>= 0.12` to support both older and newer versions (including 1.0+)
- Bump version to 0.0.9

## Test plan
- [x] Verify gem installs correctly with administrate 0.12.x
- [x] Verify gem installs correctly with administrate >= 1.0
- [x] Run `bundle exec rspec` to confirm specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates gem metadata and dependency constraints; no runtime code changes.
> 
> **Overview**
> Bumps `administrate-field-enum` version from `0.0.8` to `0.0.9`.
> 
> Relaxes the gemspec `administrate` dependency from `~> 0.12` to `>= 0.12`, allowing installation with `administrate` 1.x+ in addition to 0.12.x.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c58329ecec370d87bf2165684aa407957a2b94ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->